### PR TITLE
Update defaultdashlets.civix.php

### DIFF
--- a/defaultdashlets.civix.php
+++ b/defaultdashlets.civix.php
@@ -152,7 +152,7 @@ function _defaultdashlets_civix_find_files($dir, $pattern) {
     if ($dh = opendir($subdir)) {
       while (FALSE !== ($entry = readdir($dh))) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry{0} == '.') {
+        if ($entry[0] == '.') {
         } elseif (is_dir($path)) {
           $todos[] = $path;
         }


### PR DESCRIPTION
Minor code change to fix error "Fatal error: Array and string offset access syntax with curly braces is no longer supported in [snip]/sites/default/files/civicrm/ext/CiviCRM-Default-Dashlets/defaultdashlets.civix.php".